### PR TITLE
🐛 Add null check to closeToast to prevent undefined read error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-simple-toasts",
-  "version": "3.2.5",
+  "version": "3.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-simple-toasts",
-      "version": "3.2.5",
+      "version": "3.3.3",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-babel": "^6.0.3",
@@ -26,6 +26,9 @@
         "rollup-plugin-typescript2": "^0.34.1",
         "tslib": "^2.4.1",
         "typescript": "^4.9.4"
+      },
+      "engines": {
+        "node": ">=16.17.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=16.17.0"
+  },
   "keywords": [
     "react",
     "toast",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -214,7 +214,9 @@ const Toast = ({
 
 function closeToast(id: number) {
   const index = toastComponentList.findIndex(t => t.id === id);
-  toastComponentList[index].isExit = true;
+  if (toastComponentList[index]) {
+    toastComponentList[index].isExit = true;
+  }
   renderDOM();
 
   setTimeout(() => {


### PR DESCRIPTION
## Issue

When rapidly generating toasts, this error will sometimes occur:
```bash
Cannot set properties of undefined (setting 'isExit')
TypeError: Cannot set properties of undefined (setting 'isExit')
    at closeToast (webpack-internal:///./node_modules/react-simple-toasts/dist/index.es.js:252:38)
    at eval (webpack-internal:///./node_modules/react-simple-toasts/dist/index.es.js:327:7)
```

## Preview

[Screencast from 04-08-2023 03:47:58 PM.webm](https://user-images.githubusercontent.com/2099658/230742010-7b3e88f9-22ae-4a71-b566-cebeb9e3c193.webm)

## Solution

I added a simple null check in the `closeToast` method, and the issue is resolved

