### PR TITLE
⚙️ Chore /Delete-useless-slice

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -264,10 +264,9 @@ function renderToast(
         onClick={handleClick}
       />
     ),
-  });
-  const visibleToastOffset =
-    maxVisibleToasts && toastComponentList.length - maxVisibleToasts;
-  if (visibleToastOffset) toastComponentList.slice(visibleToastOffset);
+  };
+  if (reverse) toastComponentList.unshift(newToastComponent);
+  else toastComponentList.push(newToastComponent);
 
   if (maxVisibleToasts) {
     const toastsToRemove = toastComponentList.length - maxVisibleToasts;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -264,9 +264,7 @@ function renderToast(
         onClick={handleClick}
       />
     ),
-  };
-  if (reverse) toastComponentList.unshift(newToastComponent);
-  else toastComponentList.push(newToastComponent);
+  });
 
   if (maxVisibleToasts) {
     const toastsToRemove = toastComponentList.length - maxVisibleToasts;


### PR DESCRIPTION
## 🌁 배경
- visibleToastOffset 부분의 slice함수가 원본 배열을 변경하지 않기 때문에 이 코드가 아무런 일을 하지 않는다고 판단하였습니다.

## 👩‍💻 작업 내용 (Content)
- 제거한 코드가 있을때와 없을 때 출력값을 비교하며 코드의 작동을 확인하였습니다.
- 사진 상단의 출력결과는 코드가 있을 때이며, 하단의 결과는 코드가 없을 때 입니다.

## 📱 스크린샷
<p align="left">
  <img width="800" alt="스크린샷1" src="https://github.com/Kim-Yeon-ho/react-simple-toasts/assets/93366605/7c1c785d-6a4c-499a-beb8-1848f0de22ca">
</p>
