### PR TITLE
🐛 Bug/ Fix-Clickclosable-Option

### DIFF
--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -178,25 +178,6 @@ describe('toast', () => {
     expect(toastElement.parentElement).toHaveStyle('z-index: 10');
   });
 
-  it('renders second toast upper than first toast when reverse set to true', async () => {
-    const FIRST_TEXT = 'first message';
-    const SECOND_TEXT = 'second message';
-    await act(() => toast(FIRST_TEXT));
-    await act(() => toast(SECOND_TEXT, { reverse: true }));
-    const toastElements = screen.getAllByText(/message/);
-    expect(toastElements[0]).toHaveTextContent(SECOND_TEXT);
-  });
-
-  it('closes the reversed toast when clickClosable is true and toast is clicked ', async () => {
-    const TOAST_TEXT = 'toast message';
-    await act(() => toast(TOAST_TEXT, { reverse: true, clickClosable: true }));
-    const toastElement = screen.getByText(TOAST_TEXT);
-    await act(() => toastElement.click());
-    await waitForElementToBeRemoved(toastElement, {
-      timeout: EXIT_ANIMATION_DURATION,
-    });
-  });
-
   it('closes the toast rendered with render option when clickClosable is true and toast is clicked ', async () => {
     const TOAST_TEXT = 'toast message';
     await act(() =>

--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -177,4 +177,38 @@ describe('toast', () => {
 
     expect(toastElement.parentElement).toHaveStyle('z-index: 10');
   });
+
+  it('renders second toast upper than first toast when reverse set to true', async () => {
+    const FIRST_TEXT = 'first message';
+    const SECOND_TEXT = 'second message';
+    await act(() => toast(FIRST_TEXT));
+    await act(() => toast(SECOND_TEXT, { reverse: true }));
+    const toastElements = screen.getAllByText(/message/);
+    expect(toastElements[0]).toHaveTextContent(SECOND_TEXT);
+  });
+
+  it('closes the reversed toast when clickClosable is true and toast is clicked ', async () => {
+    const TOAST_TEXT = 'toast message';
+    await act(() => toast(TOAST_TEXT, { reverse: true, clickClosable: true }));
+    const toastElement = screen.getByText(TOAST_TEXT);
+    await act(() => toastElement.click());
+    await waitForElementToBeRemoved(toastElement, {
+      timeout: EXIT_ANIMATION_DURATION,
+    });
+  });
+
+  it('closes the toast rendered with render option when clickClosable is true and toast is clicked ', async () => {
+    const TOAST_TEXT = 'toast message';
+    await act(() =>
+      toast(TOAST_TEXT, {
+        clickClosable: true,
+        render: (message) => <div>{message}</div>,
+      }),
+    );
+    const toastElement = screen.getByText(TOAST_TEXT);
+    await act(() => toastElement.click());
+    await waitForElementToBeRemoved(toastElement, {
+      timeout: EXIT_ANIMATION_DURATION,
+    });
+  });
 });

--- a/src/component/toast-message.tsx
+++ b/src/component/toast-message.tsx
@@ -104,7 +104,7 @@ function ToastMessage({
       style={messageStyle}
     >
       {render ? (
-        render(message)
+        <div {...(clickable && clickableProps)}>{render(message)}</div>
       ) : (
         <div className={contentClassNames} {...(clickable && clickableProps)}>
           {message}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -162,6 +162,68 @@ export const clearToasts = () => {
   renderDOM();
 };
 
+const Toast = ({
+  message,
+  className,
+  clickable,
+  position,
+  isExit,
+  render,
+  onClick,
+}: ToastProps): ReactElement => {
+  const messageDOM = useRef<HTMLDivElement>(null);
+  const [isEnter, setIsEnter] = useState(false);
+
+  useLayoutEffect(() => {
+    if (messageDOM.current && messageDOM.current.clientHeight) {
+      const height = messageDOM.current.clientHeight;
+      messageDOM.current.style.height = '0px';
+      setTimeout(() => {
+        if (messageDOM.current) messageDOM.current.style.height = `${height}px`;
+        setIsEnter(true);
+      }, 0);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    const topOrCenter =
+      position && (position.indexOf('top') > -1 || position === 'center');
+    if (isExit && position && topOrCenter) {
+      if (messageDOM.current) messageDOM.current.style.height = '0px';
+    }
+  }, [isExit]);
+
+  const contentClassNames = [
+    styles['toast-content'],
+    clickable ? styles['clickable'] : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const clickableProps = {
+    onClick,
+    tabIndex: 0,
+    role: 'button',
+  };
+
+  return (
+    <div
+      ref={messageDOM}
+      className={`${styles['toast-message']} ${
+        isEnter ? 'toast-enter-active' : ''
+      } ${isExit ? 'toast-exit-active' : ''} ${className}`}
+    >
+      {render ? (
+        <div {...(clickable && clickableProps)}>{render(message)}</div>
+      ) : (
+        <div className={contentClassNames} {...(clickable && clickableProps)}>
+          {message}
+        </div>
+      )}
+    </div>
+  );
+};
+
 function closeToast(
   id: number,
   options: Pick<ToastOptions, 'onClose' | 'onCloseStart'>,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -162,68 +162,6 @@ export const clearToasts = () => {
   renderDOM();
 };
 
-const Toast = ({
-  message,
-  className,
-  clickable,
-  position,
-  isExit,
-  render,
-  onClick,
-}: ToastProps): ReactElement => {
-  const messageDOM = useRef<HTMLDivElement>(null);
-  const [isEnter, setIsEnter] = useState(false);
-
-  useLayoutEffect(() => {
-    if (messageDOM.current && messageDOM.current.clientHeight) {
-      const height = messageDOM.current.clientHeight;
-      messageDOM.current.style.height = '0px';
-      setTimeout(() => {
-        if (messageDOM.current) messageDOM.current.style.height = `${height}px`;
-        setIsEnter(true);
-      }, 0);
-    }
-  }, []);
-
-  useLayoutEffect(() => {
-    const topOrCenter =
-      position && (position.indexOf('top') > -1 || position === 'center');
-    if (isExit && position && topOrCenter) {
-      if (messageDOM.current) messageDOM.current.style.height = '0px';
-    }
-  }, [isExit]);
-
-  const contentClassNames = [
-    styles['toast-content'],
-    clickable ? styles['clickable'] : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
-
-  const clickableProps = {
-    onClick,
-    tabIndex: 0,
-    role: 'button',
-  };
-
-  return (
-    <div
-      ref={messageDOM}
-      className={`${styles['toast-message']} ${
-        isEnter ? 'toast-enter-active' : ''
-      } ${isExit ? 'toast-exit-active' : ''} ${className}`}
-    >
-      {render ? (
-        <div {...(clickable && clickableProps)}>{render(message)}</div>
-      ) : (
-        <div className={contentClassNames} {...(clickable && clickableProps)}>
-          {message}
-        </div>
-      )}
-    </div>
-  );
-};
-
 function closeToast(
   id: number,
   options: Pick<ToastOptions, 'onClose' | 'onCloseStart'>,


### PR DESCRIPTION
## 🌁 배경
- ToastMessage의 스타일을 변경하기 위해서 Render 옵션을 사용하는 중에 Clickclosable 옵션을 같이 사용하면 Clickclosable 옵션이 작동하지 않음을 확인하였습니다.
이에 위와 같은 상황에서 Clickclosable이 작동하도록 코드를 수정했습니다.

## 👩‍💻 작업 내용 (Content)
- Render 옵션을 사용했을때도 사용하지 않았을 때와 동일하게 clickableprops를 추가하였습니다.
- render와 clickclosable을 동시에 사용하였을 때 작동하여 사라는지 확인하는 테스트를 추가하였습니다.
