### PR TITLE
:technologist: Add support for 0 and null duration in toast

### DIFF
--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  act,
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { act, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import themeModuleClassNames from '../src/theme/theme-classnames.json';
 import toast from '../src';
 
@@ -129,9 +123,7 @@ describe('toast', () => {
     const TOAST_TEXT = 'message for onClose';
     const onCloseStart = jest.fn();
     const onClose = jest.fn();
-    await act(() =>
-      toast(TOAST_TEXT, { onCloseStart, onClose, clickClosable: true }),
-    );
+    await act(() => toast(TOAST_TEXT, { onCloseStart, onClose, clickClosable: true }));
 
     const toastDOM = screen.getByText(TOAST_TEXT);
     await act(() => toastDOM.click());
@@ -201,5 +193,39 @@ describe('toast', () => {
     await act(() => toast(SECOND_TEXT, { isReversedOrder: true }));
     const toastElements = screen.getAllByText(/message/);
     expect(toastElements[0]).toHaveTextContent(SECOND_TEXT);
+  });
+
+  it('should display the toast message indefinitely when duration is set to 0 or null', async () => {
+    const TOAST_TEXT = 'message for 0 duration';
+
+    jest.useFakeTimers(); // Use fake timers
+
+    await act(() => toast(TOAST_TEXT, 0));
+    await act(() => {
+      jest.runAllTimers(); // Run all pending timers
+      return Promise.resolve();
+    });
+
+    const toastElement = screen.getByText(TOAST_TEXT);
+    expect(toastElement).toBeInTheDocument();
+
+    jest.useRealTimers(); // Revert to real timers
+  });
+
+  it('should display the toast message indefinitely when duration is set to null', async () => {
+    const TOAST_TEXT = 'message for null duration';
+
+    jest.useFakeTimers(); // Use fake timers
+
+    await act(() => toast(TOAST_TEXT, null));
+    await act(() => {
+      jest.runAllTimers(); // Run all pending timers
+      return Promise.resolve();
+    });
+
+    const toastElement = screen.getByText(TOAST_TEXT);
+    expect(toastElement).toBeInTheDocument();
+
+    jest.useRealTimers(); // Revert to real timers
   });
 });

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -8,6 +8,7 @@ import.meta.globEager('/node_modules/react-simple-toasts/dist/theme/*.css');
 
 toastConfig({
   theme: 'dark',
+  duration: null,
 });
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(<App />);

--- a/example/src/page/api/api.tsx
+++ b/example/src/page/api/api.tsx
@@ -73,7 +73,7 @@ export function MyComponent() {
             <tr>
               <td>durationOrOptions</td>
               <td>
-                <code>number</code>, <code>object</code>
+                <code>number</code>, <code>object</code>, <code>null</code>
               </td>
               <td>
                 Either the duration for the toast (in milliseconds) or an object containing options
@@ -101,7 +101,8 @@ export function MyComponent() {
               </td>
               <td>
                 The duration (in milliseconds) for which the toast message will be displayed.
-                Default is <code>3000</code>.
+                Default is <code>3000</code>. Set to <code>0</code> or <code>null</code> to keep the
+                toast message displayed indefinitely.
               </td>
               <td></td>
             </tr>
@@ -331,7 +332,8 @@ export function MyComponent() {
               </td>
               <td>
                 The duration (in milliseconds) for which the toast message will be displayed.
-                Default is <code>3000</code>.
+                Default is <code>3000</code>. Set to <code>0</code> or <code>null</code> to keep the
+                toast message displayed indefinitely.
               </td>
               <td></td>
             </tr>
@@ -461,7 +463,8 @@ export function MyComponent() {
                 <code>number</code>
               </td>
               <td>
-                The vertical gap (in pixels) between consecutive toast messages. This value determines the vertical distance between toasts. Default is <code>10</code>.
+                The vertical gap (in pixels) between consecutive toast messages. This value
+                determines the vertical distance between toasts. Default is <code>10</code>.
               </td>
               <td>5.7.0</td>
             </tr>

--- a/example/src/page/change-log/change-log.tsx
+++ b/example/src/page/change-log/change-log.tsx
@@ -15,6 +15,20 @@ function ChangeLog() {
       </section>
 
       <section className={styles.new}>
+        <h3>5.8.0</h3>
+        <div className={styles.date}>{dayjs(1692359510375).format('YYYY.MM.DD')}</div>{' '}
+        <h4 className={styles.sub_title}>⚙️ Improvements</h4>
+        <ul className={styles.features}>
+          <li>
+            <strong>Duration Configuration:</strong> Added support for <code>0</code> and{' '}
+            <code>null</code> as the <code>duration</code> option. This allows the toast messages
+            not to close automatically when using these values. The existing <code>Infinity</code>{' '}
+            option will continue to create an "infinite toast."
+          </li>
+        </ul>
+      </section>
+
+      <section className={styles.new}>
         <h3>5.7.0</h3>
         <div className={styles.date}>{dayjs(1692063912987).format('YYYY.MM.DD')}</div>
 

--- a/example/src/page/example/example.tsx
+++ b/example/src/page/example/example.tsx
@@ -361,10 +361,11 @@ export default function App() {
 
           <p className={styles.description}>
             If you want to create a toast notification that stays on the screen indefinitely until
-            manually closed, you can pass <code>Infinity</code> as the duration. This will create an
-            "infinite toast". The example below shows how to create an infinite toast and provide a
-            button for manually closing it. This can be useful in scenarios where you want to make
-            sure a critical message is not missed by the user.
+            manually closed, you can pass <code>0</code>, <code>null</code>, or{' '}
+            <code>Infinity</code> as the duration. This will create an "infinite toast". The example
+            below shows how to create an infinite toast and provide a button for manually closing
+            it. This can be useful in scenarios where you want to make sure a critical message is
+            not missed by the user.
           </p>
 
           <br />
@@ -384,7 +385,7 @@ export default function App() {
 export default function App() {
   const handleShowClick = () => {
     toast('Hello, World!', {
-      duration: Infinity,
+      duration: null,
       clickClosable: true,
     });
   };
@@ -424,7 +425,7 @@ export default function App() {
   const [infiniteToast, setInfiniteToast] = useState<Toast | null>(null);
 
   const handleShowClick = () => {
-    const infiniteToast = toast('Hello, World!', { duration: Infinity });
+    const infiniteToast = toast('Hello, World!', { duration: null });
     setInfiniteToast(infiniteToast);
   };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-simple-toasts",
   "version": "5.7.0",
-  "description": "React Simple Toasts is a simple and easy-to-use toast message popup for React.",
+  "description": "Lightweight, user-friendly toast message library for React applications. Add beautiful notifications to your React apps.",
   "author": "almond-bongbong",
   "homepage": "https://github.com/almond-bongbong/react-simple-toasts",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,7 +184,7 @@ function renderToast(
     onClose = undefined,
     onCloseStart = undefined,
   } = options || {};
-  const durationTime = duration || defaultOptions.duration;
+  const durationTime = duration === undefined ? defaultOptions.duration : duration;
   const closeOptions = { onClose, onCloseStart };
 
   if (!isValidPosition(position)) {
@@ -204,7 +204,7 @@ function renderToast(
   };
 
   const startCloseTimer = (duration = durationTime, callback?: () => void) => {
-    if (duration > SET_TIMEOUT_MAX) return;
+    if (duration === null || duration === 0 || duration > SET_TIMEOUT_MAX) return;
     if (closeTimer) {
       clearTimeout(closeTimer);
     }
@@ -286,11 +286,13 @@ function renderToast(
   };
 }
 
-function toast(message: ReactNode, duration?: number): Toast;
+function toast(message: ReactNode, duration?: number | null): Toast;
 function toast(message: ReactNode, options?: ToastOptions): Toast;
-function toast(message: ReactNode, durationOrOptions?: number | ToastOptions): Toast {
+function toast(message: ReactNode, durationOrOptions?: number | null | ToastOptions): Toast {
   const options =
-    typeof durationOrOptions === 'number' ? { duration: durationOrOptions } : durationOrOptions;
+    typeof durationOrOptions === 'number' || durationOrOptions === null
+      ? { duration: durationOrOptions }
+      : durationOrOptions;
   return renderToast(message, options);
 }
 

--- a/src/type/common.ts
+++ b/src/type/common.ts
@@ -8,7 +8,7 @@ export type Theme = (typeof Themes)[keyof typeof Themes];
 export type ToastClickHandler = (e: SyntheticEvent<HTMLDivElement>) => void | Promise<void>;
 
 export interface ToastOptions {
-  duration?: number;
+  duration?: number | null;
   className?: string;
   clickable?: boolean;
   clickClosable?: boolean;
@@ -44,7 +44,7 @@ export type ConfigArgs = Pick<
 
 export interface Toast {
   close: () => void;
-  updateDuration: (duration?: number) => void;
+  updateDuration: (duration?: ToastOptions['duration']) => void;
   update: (message: ReactNode, duration?: number) => void;
 }
 


### PR DESCRIPTION
:technologist: Add Support for 0 and null Duration in Toast Notifications

**Overview**
This PR introduces the ability to set the duration of toast notifications to "0" or "null." This allows users to have a toast notification persist on the screen indefinitely or remain on the screen until manually closed.

**Changes**
- Updated type definitions to allow "0" and "null" for the duration option.
- Modified logic to prevent the toast from automatically closing when the duration is set to "0" or "null."
- Updated relevant documentation and example code to explain how to utilize this new functionality.

**How to Test**
1. Import the toast component that supports the new feature.
2. Set the duration option to "0" or "null" and display the toast.
3. Verify that the toast does not automatically close and remains on the screen.