### PR TITLE
Add named export `toast`

### DIFF
--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import themeModuleClassNames from '../src/theme/theme-classnames.json';
-import toast, {toast as toastNamed} from '../src';
+import toast, { toast as toastNamed } from '../src';
 import { generateMessage } from '../src/lib/utils';
 
 const EXIT_ANIMATION_DURATION = 320;

--- a/__tests__/toast.test.tsx
+++ b/__tests__/toast.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, render, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import themeModuleClassNames from '../src/theme/theme-classnames.json';
-import toast from '../src';
+import toast, {toast as toastNamed} from '../src';
 import { generateMessage } from '../src/lib/utils';
 
 const EXIT_ANIMATION_DURATION = 320;
@@ -242,5 +242,19 @@ describe('toast', () => {
     expect(toastElement).toBeInTheDocument();
 
     jest.useRealTimers(); // Revert to real timers
+  });
+
+  it('should renders a toast with the named export', async () => {
+    const TOAST_TEXT = generateMessage();
+    render(
+      <button type="button" onClick={() => toastNamed(TOAST_TEXT)}>
+        show
+      </button>,
+    );
+
+    const button = screen.getByText('show');
+    await act(() => button.click());
+
+    screen.getByText(TOAST_TEXT);
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -341,7 +341,7 @@ export const createToast = (options: ConfigArgs): typeof toast => {
 
 export default toast;
 
-export { Themes };
+export { Themes, toast };
 
 export type {
   ToastPosition,


### PR DESCRIPTION
I'm having some issues with the types on the default `toast` export not working and I think having a named export would resolve it for me, so this adds it.

As for the actual reason why that type is not working, I have no idea, here are my [`compilerOptions`](https://github.com/silverwind/typescript-config-silverwind/blob/5e983076da27264f5128cb9c0e48b38903f38b1f/tsconfig.json#L16).