### PR TITLE
fix: zIndex not working in update

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -294,6 +294,7 @@ function renderToast(
             baseOffsetY={offsetY}
             render={render}
             theme={finalTheme}
+            zIndex={zIndex || undefined}
             loading={finalLoading}
             onClick={handleClick}
           />


### PR DESCRIPTION
`zIndex` missing in update method.

By the way, perhaps we should refactor the option initialization logic for better maintainability:

```ts
const {
    duration,
    clickable = false,
    clickClosable = defaultOptions.clickClosable,
    className = defaultOptions.className,
    position = defaultOptions.position,
    offsetX = defaultOptions.offsetX,
    offsetY = defaultOptions.offsetY,
    gap = defaultOptions.gap,
    maxVisibleToasts = defaultOptions.maxVisibleToasts,
    isReversedOrder = defaultOptions.isReversedOrder,
    render = defaultOptions.render,
    theme = defaultOptions.theme,
    zIndex = defaultOptions.zIndex,
    loading,
    onClick = undefined,
    onClose = undefined,
    onCloseStart = undefined,
  } = options || {};
```

into like: 
```ts
options = {
  ...defaultOptions,
  ...options,
}
```

And pull out the props required by the toastMessage component:

```tsx
<ToastMessage
  id={id}
  message={finalMessage} // ?
  className={className}
  clickable={clickable || clickClosable}
  position={position}
  baseOffsetX={offsetX}
  baseOffsetY={offsetY}
  render={render}
  theme={finalTheme} // ?
  zIndex={zIndex || undefined}
  loading={finalLoading} // ?
  onClick={handleClick}
/>
```